### PR TITLE
Bugfix for Drag-and-Drop of All-Day Events in FullCalendar

### DIFF
--- a/src/features/Calendar/Calendar.js
+++ b/src/features/Calendar/Calendar.js
@@ -14,31 +14,18 @@ export default function Calendar() {
     const dispatch = useDispatch();
 
     const handleEventDrop = (info) => {
-        console.log(events);
         const { event } = info;
-        const adjustedStart = toLocalISOString(event.start);
-        const adjustedEnd = toLocalISOString(event.end);
-
-        console.log(event.id);
     
         const updatedEvent = {
             id: Number(event.id),
             title: event.title,
-            start: adjustedStart,
-            end: adjustedEnd,
+            start: event.start,
+            end: event.end,
             allDay: event.allDay
         };
     
         dispatch(updateEvent(updatedEvent));
-        console.log(events)
     };
-    
-    // Function to convert date to local ISO string
-    function toLocalISOString(date) {
-        const offset = date.getTimezoneOffset() * 60000; // offset in milliseconds
-        const adjustedDate = new Date(date.getTime() - offset);
-        return adjustedDate.toISOString().slice(0, 19); // Removes the 'Z' and milliseconds
-    }
 
     const handleEventClick = ({ event }) => {
         if (window.confirm(`Are you sure you want to delete the event '${event.title}'?`)) {

--- a/src/features/Calendar/calendarSlice.js
+++ b/src/features/Calendar/calendarSlice.js
@@ -45,7 +45,6 @@ const calendarSlice = createSlice({
     initialState,
     reducers: {
         addEvent: (state, action) => {
-            console.log(JSON.parse(JSON.stringify(state.events)));
             const newId = state.nextId++;
 
             const newEvent = {
@@ -53,7 +52,6 @@ const calendarSlice = createSlice({
                 id: newId,
             };
             state.events.push(newEvent);
-            console.log(JSON.parse(JSON.stringify(state.events)));
         },
         updateEvent: (state, action) => {
             const { id, title, start, end, allDay } = action.payload;
@@ -68,8 +66,6 @@ const calendarSlice = createSlice({
                 existingEvent.end = end;
                 existingEvent.allDay = allDay;
             }
-            // console.log(JSON.parse(JSON.stringify(state.events)))
-            // console.log(action.payload)
         },
         deleteEvent: (state, action) => {
             state.events = state.events.filter(event => event.id !== action.payload.id);


### PR DESCRIPTION
#### Description

This pull request addresses a critical bug encountered when dragging and dropping all-day events in FullCalendar. Previously, the application threw a JavaScript error ("Cannot read properties of null (reading 'getTimezoneOffset')") due to improper handling of all-day events that lack specific time information. The changes introduced in this pull request resolve this issue by properly processing the date for all-day events.

#### Files Changed

1. `Calendar.js`: Updated the `handleEventDrop` function to correctly handle all-day events without a time component.
2. `calendarSlice.js`: No significant changes affecting this bugfix, but included for completeness of the update.

#### Implementation Details

- Removed the function `toLocalISOString` within `Calendar.js` that was used to reformat dates and times as it was unnecessary and causing the error.
- This fix allows for the correct handling of both all-day events and timed events, ensuring accurate date and time representation post drag-and-drop operations.

#### Testing

- Manual testing was performed to ensure that dragging and dropping both all-day events and events with specific times works correctly, without throwing any errors.
- Additional testing and review are recommended to confirm the fix integrates well with other calendar functionalities.

#### Steps Forward

- This fix will be monitored for any unforeseen impacts on related functionalities.
- Further improvements or adjustments will be made as needed based on feedback and additional testing.

